### PR TITLE
[BUG] docker-compose.yml.template が見つからないエラー

### DIFF
--- a/devsetup.sh
+++ b/devsetup.sh
@@ -32,6 +32,8 @@ mkdir -p "${TARGET_PROJECT_DIR}/docker"
 mkdir -p "${TARGET_PROJECT_DIR}/src"
 log_info "プロジェクトディレクトリを生成したよ: ${TARGET_PROJECT_DIR}"
 
+cp -r "${TEMPLATE_DIR}/docker" "${TARGET_PROJECT_DIR}/"
+
 TEMPLATE_DIR="${SCRIPT_DIR}/templates/php-nginx-mysql"
 
 export APP_CONTAINER_NAME="${project_name}_app"

--- a/devsetup.sh
+++ b/devsetup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # ヘルパースクリプト読み込み
-SCRIPT_DIR="$(dirname "$0")"
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source "${SCRIPT_DIR}/functions/port_checker.sh"
 source "${SCRIPT_DIR}/functions/env_generator.sh"
 source "${SCRIPT_DIR}/functions/compose_generator.sh"

--- a/devsetup.sh
+++ b/devsetup.sh
@@ -59,7 +59,7 @@ env_generator "${TEMPLATE_DIR}/.env.template" "${TARGET_PROJECT_DIR}/.env"
 log_info "[完了]テンプレート設定ファイルを作成"
 
 cd "${TARGET_PROJECT_DIR}"
-log_info コンテナ起動
+log_info "コンテナ起動"
 docker compose up -d --build
 
 log_success "[完成]'${project_name}'"

--- a/devsetup.sh
+++ b/devsetup.sh
@@ -32,9 +32,11 @@ mkdir -p "${TARGET_PROJECT_DIR}/docker"
 mkdir -p "${TARGET_PROJECT_DIR}/src"
 log_info "プロジェクトディレクトリを生成したよ: ${TARGET_PROJECT_DIR}"
 
-cp -r "${TEMPLATE_DIR}/docker" "${TARGET_PROJECT_DIR}/"
-
 TEMPLATE_DIR="${SCRIPT_DIR}/templates/php-nginx-mysql"
+echo "DEBUG: TEMPLATE_DIR = ${TEMPLATE_DIR}"
+echo "DEBUG: コピー元 = ${TEMPLATE_DIR}/docker"
+
+cp -r "${TEMPLATE_DIR}/docker" "${TARGET_PROJECT_DIR}/"
 
 export APP_CONTAINER_NAME="${project_name}_app"
 export NGINX_CONTAINER_NAME="${project_name}_nginx"
@@ -57,8 +59,6 @@ log_info "選択したポート番号 → webポート: ${WEB_PORT} dbポート:
 
 compose_generator "${TEMPLATE_DIR}/docker-compose.yml.template" "${TARGET_PROJECT_DIR}/docker-compose.yml"
 env_generator "${TEMPLATE_DIR}/.env.template" "${TARGET_PROJECT_DIR}/.env"
-
-# echo "DEBUG: compose_generator - テンプレートファイル: $template_file"
 
 log_info "[完了]テンプレート設定ファイルを作成"
 

--- a/devsetup.sh
+++ b/devsetup.sh
@@ -56,6 +56,8 @@ log_info "選択したポート番号 → webポート: ${WEB_PORT} dbポート:
 compose_generator "${TEMPLATE_DIR}/docker-compose.yml.template" "${TARGET_PROJECT_DIR}/docker-compose.yml"
 env_generator "${TEMPLATE_DIR}/.env.template" "${TARGET_PROJECT_DIR}/.env"
 
+# echo "DEBUG: compose_generator - テンプレートファイル: $template_file"
+
 log_info "[完了]テンプレート設定ファイルを作成"
 
 cd "${TARGET_PROJECT_DIR}"

--- a/devsetup.sh
+++ b/devsetup.sh
@@ -60,6 +60,6 @@ log_info "[完了]テンプレート設定ファイルを作成"
 
 cd "${TARGET_PROJECT_DIR}"
 log_info コンテナ起動
-docker compose up -d --buuld
+docker compose up -d --build
 
 log_success "[完成]'${project_name}'"

--- a/devsetup.sh
+++ b/devsetup.sh
@@ -53,7 +53,7 @@ export DB_PORT
 
 log_info "選択したポート番号 → webポート: ${WEB_PORT} dbポート: ${DB_PORT}"
 
-compose_generator "${TEMPLATE_DIR}/docker-compose.yml.template" "${TARGET_PROJECT_DIR}/docker^compose.yml"
+compose_generator "${TEMPLATE_DIR}/docker-compose.yml.template" "${TARGET_PROJECT_DIR}/docker-compose.yml"
 env_generator "${TEMPLATE_DIR}/.env.template" "${TARGET_PROJECT_DIR}/.env"
 
 log_info "[完了]テンプレート設定ファイルを作成"

--- a/functions/compose_generator.sh
+++ b/functions/compose_generator.sh
@@ -4,10 +4,13 @@ compose_generator() {
   local template_file="$1"
   local output_file="$2"
 
-  if [ ! -f "template_file" ]; then
+  if [ ! -f "$template_file" ]; then
     log_error "テンプレートファイルが見つからないよ。。: ${template_file}"
     exit 1
   fi
+
+# echo "DEBUG: compose_generator - テンプレートファイル: $template_file"
+
 
   envsubst < "${template_file}" > "${output_file}"
   log_info "docker-compose.yml ファイルを作成しました！: ${output_file}"


### PR DESCRIPTION
Closes #3

## TODO
- [x] テンプレートファイル `templates/php-nginx-mysql/docker-compose.yml.template` が、プロジェクト構造内に正しく存在することを確認。
- [x] `devsetup.sh` 内で、スクリプト自身のディレクトリを基準にした絶対パスを取得するための変数 `SCRIPT_DIR` を定義。
- [x] `TEMPLATE_DIR` を、`SCRIPT_DIR` を基に適切に設定。
- [x] `compose_generator` 関数呼び出し時に、テンプレートファイルへの参照を絶対パスで指定。
- [x] 修正後、`./devsetup.sh` を実行して、テンプレートファイルが正しく読み込まれエラーが解消されることを確認する