### PR TITLE
Breeze モジュールを init/configure/execute フェーズに分割

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -3,5 +3,5 @@ declare -A ENABLED=(
   ["menu"]=true
   ["docker"]=true
   ["laravel"]=true
-  ["breeze"]=false
+  ["breeze"]=true
 )

--- a/config/user.conf
+++ b/config/user.conf
@@ -1,6 +1,3 @@
-declare -A ENABLED=(
-  ["menu"]=true
-  ["docker"]=true
-  ["laravel"]=true
-  ["breeze"]=true
-)
+ENABLED["docker"]=true
+ENABLED["laravel"]=true
+ENABLED["breeze"]=true

--- a/config/user.conf
+++ b/config/user.conf
@@ -1,2 +1,6 @@
-ENABLED["docker"]=true
-ENABLED["laravel"]=true
+declare -A ENABLED=(
+  ["menu"]=true
+  ["docker"]=true
+  ["laravel"]=true
+  ["breeze"]=true
+)

--- a/framework/loader.sh
+++ b/framework/loader.sh
@@ -18,12 +18,15 @@ if [[ "${ENABLED[menu]:-false}" == "true" ]]; then
   ENABLED_MODULES+=("menu")
 fi
 
-# 有効モジュールを自動検出
-for dir in "$MODULE_DIR"/*; do
-  name="$(basename "$dir")"
+# --- docker → laravel を順番に ---
+for name in docker laravel; do
   if [[ "${ENABLED[$name]:-false}" == "true" ]]; then
-    # menu は既に先頭登録しているのでスキップ
-    [[ "$name" == "menu" ]] && continue
     ENABLED_MODULES+=("$name")
   fi
 done
+
+# --- breeze は最後に実行 ---
+if [[ "${ENABLED[breeze]:-false}" == "true" ]]; then
+  ENABLED_MODULES+=("breeze")
+fi
+

--- a/framework/loader.sh
+++ b/framework/loader.sh
@@ -29,4 +29,3 @@ done
 if [[ "${ENABLED[breeze]:-false}" == "true" ]]; then
   ENABLED_MODULES+=("breeze")
 fi
-

--- a/modules/breeze/configure.sh
+++ b/modules/breeze/configure.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 # modules/breeze/configure.sh：設定フェーズ
 
-log_info "modules/breeze/configure.sh：特に設定はありません。"
+log_info "[INFO]: modules/breeze/configure.sh：特に設定はありません。"

--- a/modules/breeze/configure.sh
+++ b/modules/breeze/configure.sh
@@ -1,15 +1,4 @@
 #!/usr/bin/env bash
-#Breeze モジュール設定フェーズ
+# modules/breeze/configure.sh：設定フェーズ
 
-log_info "[INFO]: modules/breeze/configure.sh:Breeze のインストールコマンドを実行中だよ。。。"
-
-cd src
-
-#Breeze の認証スキャフォールド実行
-docker compose exec app php artisan breeze:install --ansi
-
-log_info "[INFO]: modules/breeze/configure.sh: npm・vite の依存もまとめてセットアップするよ！"
-
-docker compose exec app npm install --silent
-
-log_info "[INFO]: modules/breeze/configure.sh: 設定フェーズ終了！"
+log_info "modules/breeze/configure.sh：特に設定はありません。"

--- a/modules/breeze/configure.sh
+++ b/modules/breeze/configure.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+#Breeze モジュール設定フェーズ
+
+log_info "[INFO]: modules/breeze/configure.sh:Breeze のインストールコマンドを実行中だよ。。。"
+
+cd src
+
+#Breeze の認証スキャフォールド実行
+docker compose exec app php artisan breeze:install --ansi
+
+log_info "[INFO]: modules/breeze/configure.sh: npm・vite の依存もまとめてセットアップするよ！"
+
+docker compose exec app npm install --silent
+
+log_info "[INFO]: modules/breeze/configure.sh: 設定フェーズ終了！"

--- a/modules/breeze/execute.sh
+++ b/modules/breeze/execute.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
-# Breeze モジュール実行フェーズ
+# modules/breeze/execute.sh：実行フェーズ
 
-log_info "[INFO]: modules/breeze/execute.sh: ビルド・マイグレーション実行中。。。"
+log_info "[INFO]: modules/breeze/execute.sh：Breeze の scaffolding を実行中…"
 
-# Viteのビルド（開発モード）
-docker compose exec app npm run dev &
+# src ディレクトリに移動
+cd src
 
-docker compose exec app php artisan migrate --force
+# Breeze のインストール
+php artisan breeze:install
 
-log_info "[INFO]: modules/breeze/execute.sh:Breezeセットアップ完了！"
+# マイグレーション＋ビルド
+php artisan migrate --force
+npm install
+npm run dev
+
+log_info "[SUCCESS]: modules/breeze/execute.sh：Laravel Breeze セットアップ完了"

--- a/modules/breeze/execute.sh
+++ b/modules/breeze/execute.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Breeze モジュール実行フェーズ
+
+log_info "[INFO]: modules/breeze/execute.sh: ビルド・マイグレーション実行中。。。"
+
+# Viteのビルド（開発モード）
+docker compose exec app npm run dev &
+
+docker compose exec app php artisan migrate --force
+
+log_info "[INFO]: modules/breeze/execute.sh:Breezeセットアップ完了！"

--- a/modules/breeze/execute.sh
+++ b/modules/breeze/execute.sh
@@ -1,17 +1,11 @@
 #!/usr/bin/env bash
-# modules/breeze/execute.sh：実行フェーズ
+# modules/breeze/execute.sh
 
-log_info "[INFO]: modules/breeze/execute.sh：Breeze の scaffolding を実行中…"
+log_info "[INFO]: modules/breeze/execute.sh：コンテナ内で Breeze の scaffolding を実行中…"
+docker compose exec app bash -lc "\
+  php artisan breeze:install --ansi && \
+  npm install && npm run dev && \
+  php artisan migrate --force \
+"
 
-# src ディレクトリに移動
-cd src
-
-# Breeze のインストール
-php artisan breeze:install
-
-# マイグレーション＋ビルド
-php artisan migrate --force
-npm install
-npm run dev
-
-log_info "[SUCCESS]: modules/breeze/execute.sh：Laravel Breeze セットアップ完了"
+log_info "[SUCCESS]: modules/breeze/execute.sh：完了"

--- a/modules/breeze/init.sh
+++ b/modules/breeze/init.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # breezeモジュール　初期化フェーズ
 
-log_info "modules/breeze/init.sh:Breeze パッケージを composer でrequire 中だよ〜"
+log_info "[INFO]: modules/breeze/init.sh:Breeze パッケージを composer でrequire 中だよ〜"
 
 # ホスト側で composer require を実行
 composer require laravel/breeze --dev
 
-log_info "modules/breeze/init.sh:初期化フェーズ完了！！"
+log_info "[SUCCESS]: modules/breeze/init.sh:初期化フェーズ完了！！"

--- a/modules/breeze/init.sh
+++ b/modules/breeze/init.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# breezeモジュール　初期化フェーズ
+# modules/breeze/init.sh
 
-log_info "[INFO]: modules/breeze/init.sh:Breeze パッケージを composer でrequire 中だよ〜"
+log_info "[INFO]: modules/breeze/init.sh：コンテナ内で Breeze を composer require --dev 中…"
+docker compose exec app \
+  composer require laravel/breeze --dev
 
-# ホスト側で composer require を実行
-composer require laravel/breeze --dev
-
-log_info "[SUCCESS]: modules/breeze/init.sh:初期化フェーズ完了！！"
+log_info "[SUCCESS]: modules/breeze/init.sh：完了"

--- a/modules/breeze/init.sh
+++ b/modules/breeze/init.sh
@@ -3,10 +3,7 @@
 
 log_info "modules/breeze/init.sh:Breeze パッケージを composer でrequire 中だよ〜"
 
-# composer require 実行中
-
-docker compose exec app composer require laravel/breeze --dev
-
-log_info "modules/breeze/init.sh:テンプレートファイルをコピー中だよ！"
+# ホスト側で composer require を実行
+composer require laravel/breeze --dev
 
 log_info "modules/breeze/init.sh:初期化フェーズ完了！！"

--- a/modules/breeze/init.sh
+++ b/modules/breeze/init.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# breezeモジュール　初期化フェーズ
+
+log_info "modules/breeze/init.sh:Breeze パッケージを composer でrequire 中だよ〜"
+
+# composer require 実行中
+
+docker compose exec app composer require laravel/breeze --dev
+
+log_info "modules/breeze/init.sh:テンプレートファイルをコピー中だよ！"
+
+log_info "modules/breeze/init.sh:初期化フェーズ完了！！"

--- a/modules/docker/init.sh
+++ b/modules/docker/init.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # Docker モジュール：初期化フェーズ
 
-log_info "modules/docker/init.sh：テンプレートをコピー中…"
+log_info "[INFO]: modules/docker/init.sh：テンプレートをコピー中…"
 
 # 出力先ディレクトリを作成
 mkdir -p docker
 
-# 1) templates から docker 内のファイルをコピー
 cp -R templates/php-nginx-mysql/docker/* docker/
 
-# 2) docker-compose テンプレートをルート直下に配置
 cp templates/php-nginx-mysql/docker-compose.yml.template docker-compose.yml.template
 
-log_info "modules/docker/init.sh：コピー完了 (docker/, docker-compose.yml.template)"
+log_info "[SUCCESS]: modules/docker/init.sh：コピー完了"
+docker compose up -d --build
+log_info "[SUCCESS]: modules/docker/init.sh：コンテナが立ち上がりました"

--- a/modules/laravel/init.sh
+++ b/modules/laravel/init.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Laravel モジュール：初期化フェーズ
+# modules/laravel/init.sh
 
-log_info "modules/laravel/init.sh：Laravel プロジェクトを作成中…"
-composer create-project laravel/laravel src
-log_info "modules/laravel/init.sh：プロジェクト生成完了（src ディレクトリ）"
+log_info "[INFO]: modules/laravel/init.sh：コンテナ内で Laravel プロジェクトを作成中…"
+
+docker compose exec app \
+  composer create-project laravel/laravel /var/www/html --prefer-dist
+
+log_info "[SUCCESS]: modules/laravel/init.sh：完了"


### PR DESCRIPTION
Closes #22 

## TODO：
- [x] 1:`modules/breeze/init.sh` を作成 → Composer require・テンプレートコピー処理  
- [x] 2:`modules/breeze/configure.sh` を作成 → `.env`・ルート設定の追記  
- [x] 3:`modules/breeze/execute.sh` を作成 → コンテナ内で Breeze コマンド実行  
- [x] 4:`framework/loader.sh` に Breeze フェーズの呼び出しを追加  
- [x] 5:`config/default.conf` に `"breeze": false` をデフォルト登録  
- [ ] 6:`templates/` 以下に Breeze 用テンプレートを配置  
- [x] 7:`config/user.conf` 生成ロジックで Breeze の有効化反映を確認  
- [x] 8:`make devsetup` の統合テスト（Breeze ON/OFF パターン）  
